### PR TITLE
docs: stack overflow in javascript

### DIFF
--- a/eval-mbt/src/main.mbt
+++ b/eval-mbt/src/main.mbt
@@ -236,6 +236,8 @@ fn main {
     for _ in 0..<times {
       tm = App(add5, tm)
     }
+    // Stack overflow in MoonBit JavaScript backend
+    // Requires v8 JIT optimization to avoid stack overflow.
     let result = nf(tm, Nil)
     consume(result)
   }


### PR DESCRIPTION
First, use `nf` multiple times to allow the V8 JIT to optimize, then run the deep recursion example and it will not overflow the stack.

<img width="1825" height="905" alt="image" src="https://github.com/user-attachments/assets/0b5fb18a-de70-4b90-bd81-26da5effe6ea" />

<img width="1601" height="777" alt="image" src="https://github.com/user-attachments/assets/e1b15488-2951-4329-8a3d-d4c0cddb8512" />
